### PR TITLE
Add inventory dashboard and monitoring views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.cache
 /node_modules
 /public/build
+!public/build/manifest.json
 /public/hot
 /public/storage
 /storage/*.key

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,0 +1,112 @@
+{
+  "__commonjsHelpers-CqkleIqs.js": {
+    "file": "assets/_commonjsHelpers-CqkleIqs.js",
+    "name": "_commonjsHelpers"
+  },
+  "_index.html": {
+    "file": "index.html",
+    "src": "_index.html"
+  },
+  "node_modules/boxicons/fonts/boxicons.eot": {
+    "file": "assets/boxicons-CSrLvhY_.eot",
+    "src": "node_modules/boxicons/fonts/boxicons.eot"
+  },
+  "node_modules/boxicons/fonts/boxicons.svg": {
+    "file": "assets/boxicons-Dp7W9qN3.svg",
+    "src": "node_modules/boxicons/fonts/boxicons.svg"
+  },
+  "node_modules/boxicons/fonts/boxicons.ttf": {
+    "file": "assets/boxicons-EIQNrSje.ttf",
+    "src": "node_modules/boxicons/fonts/boxicons.ttf"
+  },
+  "node_modules/boxicons/fonts/boxicons.woff": {
+    "file": "assets/boxicons-CTVby2V1.woff",
+    "src": "node_modules/boxicons/fonts/boxicons.woff"
+  },
+  "node_modules/boxicons/fonts/boxicons.woff2": {
+    "file": "assets/boxicons-CeGEncwm.woff2",
+    "src": "node_modules/boxicons/fonts/boxicons.woff2"
+  },
+  "resources/assets/css/demo.css": {
+    "file": "assets/demo-ISkCbL8g.css",
+    "src": "resources/assets/css/demo.css",
+    "isEntry": true
+  },
+  "resources/assets/vendor/fonts/boxicons.scss": {
+    "file": "assets/boxicons-CGE7lhJm.css",
+    "src": "resources/assets/vendor/fonts/boxicons.scss",
+    "isEntry": true
+  },
+  "resources/assets/vendor/fonts/boxicons/boxicons.eot": {
+    "file": "assets/boxicons-CSrLvhY_.eot",
+    "src": "node_modules/boxicons/fonts/boxicons.eot"
+  },
+  "resources/assets/vendor/fonts/boxicons/boxicons.svg": {
+    "file": "assets/boxicons-Dp7W9qN3.svg",
+    "src": "node_modules/boxicons/fonts/boxicons.svg"
+  },
+  "resources/assets/vendor/fonts/boxicons/boxicons.ttf": {
+    "file": "assets/boxicons-EIQNrSje.ttf",
+    "src": "node_modules/boxicons/fonts/boxicons.ttf"
+  },
+  "resources/assets/vendor/fonts/boxicons/boxicons.woff": {
+    "file": "assets/boxicons-CTVby2V1.woff",
+    "src": "node_modules/boxicons/fonts/boxicons.woff"
+  },
+  "resources/assets/vendor/fonts/boxicons/boxicons.woff2": {
+    "file": "assets/boxicons-CeGEncwm.woff2",
+    "src": "node_modules/boxicons/fonts/boxicons.woff2"
+  },
+  "resources/assets/vendor/fonts/iconify/iconify.js": {
+    "file": "assets/iconify-DdHRVXAz.js",
+    "name": "iconify",
+    "src": "resources/assets/vendor/fonts/iconify/iconify.js",
+    "isEntry": true
+  },
+  "resources/assets/vendor/js/bootstrap.js": {
+    "file": "assets/bootstrap-BCYpfgPf.js",
+    "name": "bootstrap",
+    "src": "resources/assets/vendor/js/bootstrap.js",
+    "isEntry": true
+  },
+  "resources/assets/vendor/libs/jquery/jquery.js": {
+    "file": "assets/jquery-Bh41zue2.js",
+    "name": "jquery",
+    "src": "resources/assets/vendor/libs/jquery/jquery.js",
+    "isEntry": true,
+    "imports": [
+      "__commonjsHelpers-CqkleIqs.js"
+    ]
+  },
+  "resources/assets/vendor/libs/popper/popper.js": {
+    "file": "assets/popper-Ck0tsB3H.js",
+    "name": "popper",
+    "src": "resources/assets/vendor/libs/popper/popper.js",
+    "isEntry": true,
+    "imports": [
+      "__commonjsHelpers-CqkleIqs.js"
+    ]
+  },
+  "resources/assets/vendor/scss/core.scss": {
+    "file": "assets/core-Bd8T5dqT.css",
+    "src": "resources/assets/vendor/scss/core.scss",
+    "isEntry": true
+  },
+  "resources/assets/vendor/scss/pages/page-auth.scss": {
+    "file": "assets/page-auth-BET8THlp.css",
+    "src": "resources/assets/vendor/scss/pages/page-auth.scss",
+    "isEntry": true
+  },
+  "resources/css/app.css": {
+    "file": "assets/app-l0sNRNKZ.js",
+    "name": "app",
+    "src": "resources/css/app.css",
+    "isEntry": true
+  },
+  "resources/js/app.js": {
+    "file": "assets/app-C0G0cght.js",
+    "name": "app",
+    "src": "resources/js/app.js",
+    "isEntry": true
+  }
+}

--- a/resources/views/bpgs/create.blade.php
+++ b/resources/views/bpgs/create.blade.php
@@ -1,0 +1,55 @@
+@section('title', __('Buat BPG'))
+<x-layouts.app :title="__('Buat BPG')">
+    <form>
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Tanggal') }}</label>
+                <input type="date" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('No. BPG') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Supplier') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Nomor Mobil / Dokumen') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Item') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Lot Number') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('QTY (kg)') }}</label>
+                <input type="number" step="0.001" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('QTY Aktual (kg)') }}</label>
+                <input type="number" step="0.001" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Loss (kg / %)') }}</label>
+                <input type="text" class="form-control" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">{{ __('Coly') }}</label>
+                <input type="number" class="form-control" />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">{{ __('Catatan') }}</label>
+                <textarea class="form-control"></textarea>
+            </div>
+        </div>
+        <div class="mt-4">
+            <button type="submit" class="btn btn-primary">{{ __('Simpan Draft') }}</button>
+            <button type="submit" class="btn btn-outline-primary">{{ __('Posting') }}</button>
+        </div>
+    </form>
+</x-layouts.app>

--- a/resources/views/bpgs/index.blade.php
+++ b/resources/views/bpgs/index.blade.php
@@ -1,0 +1,30 @@
+@section('title', __('Daftar BPG'))
+<x-layouts.app :title="__('Daftar BPG')">
+    <div class="d-flex mb-3">
+        <a href="{{ route('bpgs.create') }}" class="btn btn-primary">{{ __('Buat BPG') }}</a>
+    </div>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>{{ __('No. BPG') }}</th>
+                <th>{{ __('Tanggal') }}</th>
+                <th>{{ __('Supplier') }}</th>
+                <th>{{ __('Nomor Mobil') }}</th>
+                <th>{{ __('Lot Number') }}</th>
+                <th>{{ __('Item') }}</th>
+                <th>{{ __('QTY (kg)') }}</th>
+                <th>{{ __('QTY Aktual') }}</th>
+                <th>{{ __('Loss') }}</th>
+                <th>{{ __('Coly') }}</th>
+                <th>{{ __('Diterima oleh') }}</th>
+                <th>{{ __('Status') }}</th>
+                <th>{{ __('Aksi') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td colspan="13" class="text-center text-muted">{{ __('Belum ada data') }}</td>
+            </tr>
+        </tbody>
+    </table>
+</x-layouts.app>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,25 +1,61 @@
 @section('title', __('Dashboard'))
 <x-layouts.app :title="__('Dashboard')">
-    <div class="row g-4">
-        <div class="col-lg-4">
-          <div class="overflow-hidden rounded border" style="aspect-ratio: 16/6;">
-            <x-placeholder-pattern class="h-100 w-100" style="stroke: color-mix(in oklab, oklch(.21 .034 264.665) 20%, transparent);" />
-          </div>
+    <div class="row g-4 mb-4">
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">{{ __('Transaksi hari ini') }}</h6>
+                    <p class="card-text fw-bold display-6">0</p>
+                </div>
+            </div>
         </div>
-        <div class="col-lg-4">
-          <div class="overflow-hidden rounded border" style="aspect-ratio: 16/6;">
-            <x-placeholder-pattern class="h-100 w-100" style="stroke: color-mix(in oklab, oklch(.21 .034 264.665) 20%, transparent);" />
-          </div>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">{{ __('Top 5 stok rendah') }}</h6>
+                    <ol class="mb-0 small">
+                        <li>Item A</li>
+                        <li>Item B</li>
+                        <li>Item C</li>
+                        <li>Item D</li>
+                        <li>Item E</li>
+                    </ol>
+                </div>
+            </div>
         </div>
-        <div class="col-lg-4">
-          <div class="overflow-hidden rounded border" style="aspect-ratio: 16/6;">
-            <x-placeholder-pattern class="h-100 w-100" style="stroke: color-mix(in oklab, oklch(.21 .034 264.665) 20%, transparent);" />
-          </div>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">{{ __('Loss tertinggi') }}</h6>
+                    <p class="card-text mb-0">-</p>
+                </div>
+            </div>
         </div>
-        <div class="col-lg-12">
-          <div class="overflow-hidden rounded border" style="aspect-ratio: 16/6;">
-            <x-placeholder-pattern class="h-100 w-100" style="stroke: color-mix(in oklab, oklch(.21 .034 264.665) 20%, transparent);" />
-          </div>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">{{ __('Batch mixing aktif') }}</h6>
+                    <p class="card-text mb-0">-</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mb-4">
+        <a href="{{ route('bpgs.create') }}" class="btn btn-primary me-2">{{ __('Input BPG') }}</a>
+        <a href="{{ route('ttpbs.create') }}" class="btn btn-outline-primary me-2">{{ __('Buat TTPB') }}</a>
+        <a href="#" class="btn btn-outline-primary">{{ __('Batch Mixing') }}</a>
+    </div>
+
+    <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span>{{ __('IN vs OUT per lokasi') }}</span>
+            <select class="form-select w-auto">
+                <option>{{ __('Pilih Periode') }}</option>
+            </select>
+        </div>
+        <div class="card-body">
+            <div class="bg-light border rounded" style="height:200px;"></div>
         </div>
     </div>
 </x-layouts.app>

--- a/resources/views/monitoring.blade.php
+++ b/resources/views/monitoring.blade.php
@@ -1,0 +1,77 @@
+@section('title', __('Monitoring'))
+<x-layouts.app :title="__('Monitoring')">
+    <form class="row g-2 mb-4">
+        <div class="col-md-3">
+            <label class="form-label">{{ __('Tanggal Dari') }}</label>
+            <input type="date" class="form-control" />
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">{{ __('Tanggal Sampai') }}</label>
+            <input type="date" class="form-control" />
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">{{ __('Item') }}</label>
+            <input type="text" class="form-control" />
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">{{ __('Lot Number') }}</label>
+            <input type="text" class="form-control" />
+        </div>
+    </form>
+
+    <ul class="nav nav-tabs" id="monitoringTab" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="stok-tab" data-bs-toggle="tab" data-bs-target="#stok" type="button" role="tab">{{ __('Stok Saat Ini') }}</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="ledger-tab" data-bs-toggle="tab" data-bs-target="#ledger" type="button" role="tab">{{ __('Kartu Stok / Ledger') }}</button>
+        </li>
+    </ul>
+    <div class="tab-content mt-3" id="monitoringTabContent">
+        <div class="tab-pane fade show active" id="stok" role="tabpanel" aria-labelledby="stok-tab">
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th>{{ __('Lokasi') }}</th>
+                        <th>{{ __('Item') }}</th>
+                        <th>{{ __('Lot Number') }}</th>
+                        <th>{{ __('QTY (kg)') }}</th>
+                        <th>{{ __('Coly') }}</th>
+                        <th>{{ __('Terakhir Update') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td colspan="6" class="text-center text-muted">{{ __('Belum ada data') }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="tab-pane fade" id="ledger" role="tabpanel" aria-labelledby="ledger-tab">
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th>{{ __('Tanggal') }}</th>
+                        <th>{{ __('Ref') }}</th>
+                        <th>{{ __('Dari → Ke') }}</th>
+                        <th>{{ __('Item') }}</th>
+                        <th>{{ __('Lot Number') }}</th>
+                        <th>{{ __('IN') }}</th>
+                        <th>{{ __('OUT') }}</th>
+                        <th>{{ __('Saldo') }}</th>
+                        <th>{{ __('User') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td colspan="9" class="text-center text-muted">{{ __('Belum ada data') }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="d-flex justify-content-end gap-2">
+                <button class="btn btn-outline-secondary">{{ __('Export Excel') }}</button>
+                <button class="btn btn-outline-secondary">{{ __('Export PDF') }}</button>
+            </div>
+        </div>
+    </div>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,18 @@ Route::view('dashboard', 'dashboard')
   ->middleware(['auth', 'verified'])
   ->name('dashboard');
 
+Route::view('monitoring', 'monitoring')
+  ->middleware(['auth', 'verified'])
+  ->name('monitoring');
+
+Route::view('bpgs', 'bpgs.index')
+  ->middleware(['auth', 'verified'])
+  ->name('bpgs.index');
+
+Route::view('bpgs/create', 'bpgs.create')
+  ->middleware(['auth', 'verified'])
+  ->name('bpgs.create');
+
 Route::middleware(['auth'])->group(function () {
   Route::redirect('settings', 'settings/profile');
 


### PR DESCRIPTION
## Summary
- Enhance dashboard with quick stats, shortcuts, and chart placeholder
- Add monitoring page with filters and stock/ledger tabs
- Scaffold basic BPG listing and creation views

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689ef90bb77883308748906b2a192ded