### PR TITLE
Fix BPG menu route to use BPG input page

### DIFF
--- a/config/menu.php
+++ b/config/menu.php
@@ -18,8 +18,8 @@ return [
             ],
             [
                 'label' => 'BPG – Input',
-                'route' => 'gudang.bpg.create',
-                'active' => 'gudang.bpg.*',
+                'route' => 'bpgs.create',
+                'active' => 'bpgs.*',
             ],
             [
                 'label' => 'TTPB – Daftar',


### PR DESCRIPTION
## Summary
- Link BPG Input menu to the existing BPG creation page

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689f03153da48330a91bf51bb12c732c