### PR TITLE
Fix null from location error on TTPB create page

### DIFF
--- a/resources/views/ttpbs/create.blade.php
+++ b/resources/views/ttpbs/create.blade.php
@@ -12,8 +12,8 @@
         </div>
         <div class="mb-3">
             <label class="form-label">{{ __('From Location') }}</label>
-            <input type="text" class="form-control" value="{{ $fromLocation->name ?? $fromLocation->id }}" readonly>
-            <input type="hidden" name="from_location_id" value="{{ $fromLocation->id }}">
+            <input type="text" class="form-control" value="{{ optional($fromLocation)->name ?? optional($fromLocation)->id ?? '' }}" readonly>
+            <input type="hidden" name="from_location_id" value="{{ optional($fromLocation)->id }}">
         </div>
         <div class="mb-3">
             <label class="form-label">{{ __('To Location') }}</label>


### PR DESCRIPTION
## Summary
- handle missing `fromLocation` in TTPB create view to avoid null `id` access

## Testing
- `./vendor/bin/pest` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f0bb15430833085ac1ddc56669a54